### PR TITLE
Bugfix: The plugin would emit manifest.js

### DIFF
--- a/chrome-manifest-plugin.js
+++ b/chrome-manifest-plugin.js
@@ -13,7 +13,6 @@ ChromeManifestPlugin.prototype.apply = function(compiler) {
     compiler.options.entry = {'main': compiler.options.entry};
   }
   compiler.options.entry.manifest = this.options.manifest;
-  compiler.options.output.filename = '[name].js';
   compiler.options.module.rules.push({
     test: /manifest\.json$/,
     loader: path.join(__dirname, "manifest-loader.js"),


### PR DESCRIPTION
Currently, the plugin generates a manifest.js file because it overwrites the output file to be [name].js (which doesn't make sense for json files).