### PR TITLE
Bugfix: package.json overwrote manifest.json

### DIFF
--- a/manifest-loader.js
+++ b/manifest-loader.js
@@ -4,14 +4,14 @@ const fs = require('fs');
 module.exports = function(source) {
   let options = loaderUtils.getOptions(this);
   const pkg = JSON.parse(fs.readFileSync('./package.json'));
-  const merged = Object.assign({}, JSON.parse(source), {
+  const merged = Object.assign({}, {
     'manifest_version': 2,
     'name': pkg.name,
     'description': pkg.description,
     'version': pkg.version,
     'author': pkg.author,
     'homepage_url': pkg.homepage,
-  });
+  }, JSON.parse(source));
   const mergedJson = JSON.stringify(merged);
   this.emitFile('manifest.json', mergedJson);
   return mergedJson;


### PR DESCRIPTION
Currently, the package.json overwrites anything in manifest.json.
It would be better, if it was the other way around.

For example, the name in manifest.json might be MyApp, while package.json expects a name in the form of reverse.url.myapp.
With this change, you could choose which variables you want to have overwritten by just not including them inside manifest.json.